### PR TITLE
refactor: improve error handling, Geyser startup, and CLI robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,8 +3384,10 @@ dependencies = [
  "quinn",
  "rcgen 0.11.3",
  "rustls",
+ "solana-client",
  "solana-sdk",
  "thiserror",
+ "tonic",
 ]
 
 [[package]]

--- a/crates/scramjet-common/Cargo.toml
+++ b/crates/scramjet-common/Cargo.toml
@@ -8,8 +8,10 @@ license.workspace = true
 
 [dependencies]
 solana-sdk = { workspace = true }
+solana-client = { workspace = true }
 rustls = { workspace = true }
 rcgen = { workspace = true }
 quinn = { workspace = true }
+tonic = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/scramjet-common/src/config.rs
+++ b/crates/scramjet-common/src/config.rs
@@ -153,12 +153,22 @@ impl Config {
     }
 }
 
-/// Helper to parse env var with default fallback
-fn parse_env<T: std::str::FromStr>(key: &str, default: T) -> T {
-    env::var(key)
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(default)
+/// Helper to parse env var with default fallback.
+/// Logs a warning if the value exists but fails to parse.
+fn parse_env<T: std::str::FromStr + std::fmt::Display>(key: &str, default: T) -> T {
+    match env::var(key) {
+        Ok(v) => match v.parse() {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                eprintln!(
+                    "Warning: Invalid value for {}: '{}', using default {}",
+                    key, v, default
+                );
+                default
+            }
+        },
+        Err(_) => default,
+    }
 }
 
 #[cfg(test)]

--- a/crates/scramjet-common/src/error.rs
+++ b/crates/scramjet-common/src/error.rs
@@ -2,22 +2,82 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ScramjetError {
+    // --- Configuration ---
     #[error("Configuration error: {0}")]
     ConfigError(String),
     #[error("Configuration validation error: {0}")]
     ConfigValidationError(String),
+
+    // --- Certificate/Identity ---
     #[error("Certificate generation error: {0}")]
     CertError(String),
-    #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
-    #[error("Invalid pubkey: {0}")]
-    InvalidPubkey(String),
     #[error("Keypair error: {0}")]
     KeypairError(String),
+    #[error("Home directory not found")]
+    HomeDirNotFound,
+
+    // --- IO ---
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    // --- Parsing ---
+    #[error("Invalid pubkey: {0}")]
+    InvalidPubkey(String),
+    #[error("Invalid URI: {0}")]
+    InvalidUri(String),
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
+
+    // --- QUIC/Transport ---
     #[error("Connection error: {0}")]
     ConnectionError(String),
+    #[error("QUIC transport error: {0}")]
+    TransportError(#[from] quinn::ConnectionError),
+    #[error("QUIC write error: {0}")]
+    WriteError(#[from] quinn::WriteError),
+    #[error("Stream error: {0}")]
+    StreamError(String),
+
+    // --- gRPC/Tonic (boxed to reduce Result size) ---
+    #[error("gRPC transport error: {0}")]
+    GrpcTransportError(#[from] tonic::transport::Error),
+    #[error("gRPC status error: {0}")]
+    GrpcStatusError(#[source] Box<tonic::Status>),
+
+    // --- Geyser ---
     #[error("Geyser error: {0}")]
     GeyserError(String),
+    #[error("Geyser stream closed unexpectedly")]
+    GeyserStreamClosed,
+
+    // --- RPC/Solana Client (boxed - 224 bytes otherwise) ---
     #[error("RPC error: {0}")]
     RpcError(String),
+    #[error("Solana client error: {0}")]
+    SolanaClientError(#[source] Box<solana_client::client_error::ClientError>),
+
+    // --- Topology ---
+    #[error("No leader found for slot {0}")]
+    NoLeaderFound(u64),
+    #[error("Leader schedule unavailable")]
+    ScheduleUnavailable,
+
+    // --- Async/Channel ---
+    #[error("Channel error: {0}")]
+    ChannelError(String),
+    #[error("Startup timeout")]
+    StartupTimeout,
+}
+
+// Manual From implementations for boxed types
+impl From<tonic::Status> for ScramjetError {
+    fn from(err: tonic::Status) -> Self {
+        ScramjetError::GrpcStatusError(Box::new(err))
+    }
+}
+
+impl From<solana_client::client_error::ClientError> for ScramjetError {
+    fn from(err: solana_client::client_error::ClientError) -> Self {
+        ScramjetError::SolanaClientError(Box::new(err))
+    }
 }

--- a/crates/scramjet-common/src/lib.rs
+++ b/crates/scramjet-common/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod identity;
 
 pub use config::Config;
+pub use error::ScramjetError;
 pub use identity::create_quic_config;
 
 // --- UNIT TEST ---


### PR DESCRIPTION
refactor: improve error handling, Geyser startup, and CLI robustness

- Unified error handling across `scramjet-net` using `ScramjetError` (replacing `anyhow`).
- Enhanced `ScramjetError` with new variants for gRPC, Solana client, and stream errors.
- Added Geyser startup signaling with a oneshot receiver for initial connection status.
- Improved CLI error messages and fallback logic for keypair path resolution.
- Added timeout and detailed logging for Geyser initialization in CLI.
- Updated `scramjet-common` config parsing to log warnings for invalid environment variables.
- Updated dependencies (`solana-client`, `tonic`) and Cargo.lock.
